### PR TITLE
fix apt repository

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -6,7 +6,7 @@ RUN set -x && \
     apt-get install -y apt-transport-https && \
     apt-get install -y software-properties-common && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 && \
-    apt-add-repository "deb http://repo.yandex.ru/clickhouse/xenial stable main" && \
+    apt-add-repository "deb http://repo.yandex.ru/clickhouse/deb/stable/ main/" && \
     apt-get update && \
     apt-get install clickhouse-server-common clickhouse-client -y
 


### PR DESCRIPTION
fix for https://github.com/ClickHouse/ClickHouse/issues/2060

```
Err:7 http://repo.yandex.ru/clickhouse/xenial stable/main amd64 Packages
  404  Not Found
Ign:8 http://repo.yandex.ru/clickhouse/xenial stable/main all Packages
Reading package lists...
W: The repository 'http://repo.yandex.ru/clickhouse/xenial stable Release' does not have a Release file.
E: Failed to fetch http://repo.yandex.ru/clickhouse/xenial/dists/stable/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
ERROR: Service 'clickhouse-master' failed to build: The command '/bin/sh -c set -x &&     apt-get update &&     apt-get dist-upgrade -y &&     apt-get install -y apt-transport-https &&     apt-get install -y software-properties-common &&     apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4 &&     apt-add-repository "deb http://repo.yandex.ru/clickhouse/xenial stable main" &&     apt-get update &&     apt-get install clickhouse-server-common clickhouse-client -y' returned a non-zero code: 100
```